### PR TITLE
Repair workflows and check pull requests before merging

### DIFF
--- a/.github/workflows/document-check-and-covr.yaml
+++ b/.github/workflows/document-check-and-covr.yaml
@@ -3,47 +3,60 @@ on:
     branches:
       - main
       - master
+  pull_request:
+  workflow_dispatch:
 
 name: R-CMD-check
+
+permissions:
+  contents: read
 
 jobs:
   document-and-dispatch:
     name: document
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - uses: r-lib/actions/setup-r@v2
         with:
           use-public-rspm: true
           r-version: 'release'
       - name: Delete-Namespace
-        run: Rscript -e 'file.remove("NAMESPACE")'          
+        run: Rscript -e 'file.remove("NAMESPACE")'
       - uses: r-lib/actions/setup-pandoc@v2
-      - name: system dependencies
-        run: sudo apt-get install libcurl4-openssl-dev libnode-dev
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: any::rcmdcheck, any::roxygen2
+          extra-packages: any::rcmdcheck, any::roxygen2, any::cffr, any::covr
           needs: check
 
       - name: Document
-        run: Rscript -e 'roxygen2::roxygenise()'
-        
-      - name: commit
+        run: |
+          roxygen2::roxygenise()
+          if (file.exists("CITATION.cff")) cffr::cff_write()
+        shell: Rscript {0}
+
+      - uses: r-lib/actions/check-r-package@v2
+
+      - name: Test coverage
+        if: github.event_name == 'push'
+        run: |
+          covr::codecov()
+        shell: Rscript {0}
+
+      - name: Commit generated documentation
+        if: github.event_name == 'push'
         run: |
           git config --local user.email "actions@github.com"
           git config --local user.name "GitHub Actions"
-          git add -f man/\* NAMESPACE
-          git commit -m 'Documentation' || echo "No changes to commit"
-          git push origin || echo "No changes to commit"
-    
-        
-      - uses: r-lib/actions/check-r-package@v2
-         
-      - name: Test coverage
-        run: |
-          install.packages(c("covr"))
-          covr::codecov()
-        shell: Rscript {0}
+          git add -A -f -- man NAMESPACE
+          if git ls-files --error-unmatch CITATION.cff >/dev/null 2>&1; then
+            git add CITATION.cff
+          fi
+          if ! git diff --cached --quiet; then
+            git commit -m 'Documentation'
+            git push origin HEAD:"${GITHUB_REF_NAME}"
+          fi

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -4,9 +4,12 @@ on:
       - main
       - master
     tags:
-      -'*'
+      - '*'
 
 name: pkgdown
+
+permissions:
+  contents: write
 
 jobs:
   pkgdown:
@@ -14,11 +17,11 @@ jobs:
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
 
       - uses: r-lib/actions/setup-r@v2
 
-      - uses: r-lib/actions/setup-pandoc@v1
+      - uses: r-lib/actions/setup-pandoc@v2
 
       - name: Query dependencies
         run: |

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # rsprite2 0.2.1.9002
 
+* Maintenance: fixed workflow syntax and enabled package checks on pull requests. Documentation is committed only after successful checks on branch pushes. These changes improve release checks and do not alter statistical results.
+
 * Changed implementation of `GRIM_test()` to more direct calculation rather than iterative check to increase transparency and efficiency. If requested to return the nearest possible means, the function now also correctly returns two values if there are two equidistant values. (For users wishing to use the original algorithm, it is presently retained as an *unexported* function that can be called with `rsprite2:::GRIM_test_old()`.)
 * Changed implementation of `GRIMMER_test()` to account for the fact that multiple exact means may be compatible with the reported means, if the mean is reported to a lower precision than the standard deviation. The previous version missed some valid SDs in this rare case. Also optimised the implementation of the algorithm to catch special cases explicitly and run a lot faster.
 * Added a `boundary_test()` function that tests whether a standard deviation is within the possible range. This tests was already part of GRIMMER, but is now exported and separately documented for transparency. The underlying function to calculate SD limits now also accounts for various rounding choices for values ending in .5, i.e. up, down or to even, to reduce the risk of false positives, and is vectorised to increase speed.


### PR DESCRIPTION
The audit found malformed workflow syntax and no package checks on pull requests. This enables PR checks, repairs the pkgdown tag filter, and combines documentation commands into one valid R step. It also preserves the pending citation-generation intent when a CITATION.cff file is present.

Impact: this is maintenance for release checks, not a fix to statistical results. PR runs regenerate documentation and check the package without committing or deploying. Branch pushes commit generated documentation only after the checks succeed, and push failures now fail visibly.

Validation: both workflows parse with `yaml::read_yaml()` and pass `actionlint`. Reviewed twice with `claude -p --model fable`; the final review found no blockers. Follow-up changes stage deleted documentation, delegate system dependencies to r-lib/actions, and keep coverage uploads on branch pushes. Remote PR checks will be required to pass.

Audit coverage: [Astra F13](https://rsprite2-audit-astra-2026-09-09.surge.sh/#f13). No upstream rSPRITE files are changed.
