### PR TITLE
Preserve response frequencies and endpoint bars in plots

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,8 +1,8 @@
 # rsprite2 0.2.1.9002
 
 * Maintenance: fixed workflow syntax and enabled package checks on pull requests. Documentation is committed only after successful checks on branch pushes. These changes improve release checks and do not alter statistical results.
-* Fixed distribution plots to retain complete endpoint bars and show exact response frequencies, including multi-item scales, gaps, and constant distributions. Empty search results now produce a clear plotting diagnostic.
-* Hardened plotting of manually supplied data: invalid distribution vectors and scalar controls now produce clear errors; density plots reject distributions with fewer than two distinct responses.
+* Ordinary use: fixed distribution plots to retain complete endpoint bars and show exact response frequencies, including multi-item scales, gaps, and constant distributions. Empty search results now produce a clear plotting diagnostic.
+* Rare-input hardening: for manually supplied data, invalid distribution vectors and scalar controls now produce clear errors; density plots reject distributions with fewer than two distinct responses.
 
 * Changed implementation of `GRIM_test()` to more direct calculation rather than iterative check to increase transparency and efficiency. If requested to return the nearest possible means, the function now also correctly returns two values if there are two equidistant values. (For users wishing to use the original algorithm, it is presently retained as an *unexported* function that can be called with `rsprite2:::GRIM_test_old()`.)
 * Changed implementation of `GRIMMER_test()` to account for the fact that multiple exact means may be compatible with the reported means, if the mean is reported to a lower precision than the standard deviation. The previous version missed some valid SDs in this rare case. Also optimised the implementation of the algorithm to catch special cases explicitly and run a lot faster.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
 # rsprite2 0.2.1.9002
 
 * Maintenance: fixed workflow syntax and enabled package checks on pull requests. Documentation is committed only after successful checks on branch pushes. These changes improve release checks and do not alter statistical results.
+* Fixed distribution plots to retain complete endpoint bars and show exact response frequencies, including multi-item scales, gaps, and constant distributions. Empty search results now produce a clear plotting diagnostic.
+* Hardened plotting of manually supplied data: invalid distribution vectors and scalar controls now produce clear errors; density plots reject distributions with fewer than two distinct responses.
 
 * Changed implementation of `GRIM_test()` to more direct calculation rather than iterative check to increase transparency and efficiency. If requested to return the nearest possible means, the function now also correctly returns two values if there are two equidistant values. (For users wishing to use the original algorithm, it is presently retained as an *unexported* function that can be called with `rsprite2:::GRIM_test_old()`.)
 * Changed implementation of `GRIMMER_test()` to account for the fact that multiple exact means may be compatible with the reported means, if the mean is reported to a lower precision than the standard deviation. The previous version missed some valid SDs in this rare case. Also optimised the implementation of the algorithm to catch special cases explicitly and run a lot faster.

--- a/R/plot-functions.R
+++ b/R/plot-functions.R
@@ -4,11 +4,17 @@
 #' They can be shown as histograms or as \href{https://towardsdatascience.com/what-why-and-how-to-read-empirical-cdf-123e2b922480}{cumulative distributions (ECDF) plots}. The latter give
 #' more information, yet not all audiences are familiar with them.
 #'
-#' @param distributions Tibble with a column `distribution` and an identifier (`id`), typically as returned from \code{\link{find_possible_distributions}}.
+#' @param distributions Nonempty tibble with a list-column `distribution` containing nonempty, finite numeric vectors, and an identifier (`id`), typically as returned from \code{\link{find_possible_distributions}}. Density plots require at least two distinct responses in each distribution.
 #' @param plot_type Plot multiple histograms, or overlapping cumulative distribution plots, or density plots? "auto" is to plot histograms if up to 9 distributions are passed, or if there are fewer than 10 discrete values, and empirical cumulative distribution plots otherwise
-#' @param max_plots How many distributions should *at most* be plotted? If more are passed, this number is randomly selected.
+#' @param max_plots Positive integer: how many distributions should *at most* be plotted? If more are passed, this number is randomly selected.
 #' @param show_ids Should ids of the distributions be shown with ecdf and density charts? Defaults to no, since the default ids are not meaningful.
 #' @param facets Should distributions be shown in one chart or in multiple small charts? Only considered for ecdf and density charts, histograms are always shown in facets
+#'
+#' @details Histograms show the exact frequency at each observed response. Bar widths
+#' use the response spacing (`1 / n_items`) for SPRITE results. For ordinary
+#' tibbles, widths use the smallest observed spacing, or 1 if all responses are
+#' identical. Scale endpoints and complete bars are retained. Empty inputs
+#' produce an informative error.
 #'
 #' @return A ggplot2 object that can be styled with functions such as \code{\link[ggplot2]{labs}} or \code{\link[ggplot2]{theme_linedraw}}
 
@@ -28,7 +34,7 @@
 
 plot_distributions <- function(distributions, plot_type = c("auto", "histogram", "ecdf", "density"),
                                max_plots = 100, show_ids = FALSE, facets = NULL) {
-  .check_req_packages(c("tidyr", "ggplot2", "rlang"))
+  .check_req_packages(c("tidyr", "ggplot2", "rlang", "scales"))
 
   # To avoid depending on rlang, this cannot be imported
   .data <- rlang::.data
@@ -38,8 +44,24 @@ plot_distributions <- function(distributions, plot_type = c("auto", "histogram",
 
   assert_tibble(distributions)
   assert_subset(c("id", "distribution"), names(distributions))
-  assert_choice(plot_type[1], c("auto", "histogram", "ecdf", "density"))
-  plot_type <- plot_type[1]
+  if (missing(plot_type)) plot_type <- "auto"
+  assert_choice(plot_type, c("auto", "histogram", "ecdf", "density"))
+  assert_int(max_plots, lower = 1)
+  assert_flag(show_ids)
+  if (!is.null(facets)) assert_flag(facets)
+  if (nrow(distributions) == 0L) {
+    stop("No distributions to plot: provide at least one distribution.", call. = FALSE)
+  }
+  if (!is.list(distributions$distribution) ||
+      !all(vapply(distributions$distribution, function(x) {
+        is.numeric(x) && is.null(dim(x)) && length(x) > 0L && all(is.finite(x))
+      }, logical(1)))) {
+    stop("distribution must be a list-column of nonempty, finite numeric vectors.", call. = FALSE)
+  }
+  if (plot_type == "density" &&
+      any(vapply(distributions$distribution, function(x) length(unique(x)) < 2L, logical(1)))) {
+    stop("Density plots require at least two distinct responses in each distribution.", call. = FALSE)
+  }
 
   if (any(duplicated(distributions$id))) {
     warning("id column should not contain duplicates. Replaced by row number instead.")
@@ -79,15 +101,23 @@ plot_distributions <- function(distributions, plot_type = c("auto", "histogram",
     facets <- FALSE
   }
 
-  assert_logical(facets)
-
-  p <- ggplot2::ggplot(distributions_long, ggplot2::aes(x = .data$distribution)) + ggplot2::theme_light() +
-    ggplot2::scale_x_continuous(limits = c(scale_min, scale_max))
-
+  p <- ggplot2::ggplot(distributions_long, ggplot2::aes(x = .data$distribution)) +
+    ggplot2::theme_light()
 
   if (plot_type == "histogram") {
-    bins <- min(30, unique_vals)
-    p <- p + ggplot2::geom_histogram(bins = bins)
+    if (inherits(distributions, "sprite_distributions")) {
+      spacing <- 1 / params$n_items
+    } else {
+      gaps <- diff(sort(unique(distributions_long$distribution)))
+      spacing <- if (length(gaps)) min(gaps) else 1
+    }
+    # Train on bar extents as well as the declared scale, so endpoint bars
+    # remain complete and responses are never merged into arbitrary bins.
+    p <- p + ggplot2::geom_bar(width = 0.9 * spacing) +
+      ggplot2::scale_x_continuous(limits = function(x) range(x, scale_min, scale_max)) +
+      ggplot2::labs(x = "Response", y = "Count")
+  } else {
+    p <- p + ggplot2::scale_x_continuous(limits = c(scale_min, scale_max))
   }
 
   if (plot_type == "density") {

--- a/man/plot_distributions.Rd
+++ b/man/plot_distributions.Rd
@@ -13,11 +13,11 @@ plot_distributions(
 )
 }
 \arguments{
-\item{distributions}{Tibble with a column \code{distribution} and an identifier (\code{id}), typically as returned from \code{\link{find_possible_distributions}}.}
+\item{distributions}{Nonempty tibble with a list-column \code{distribution} containing nonempty, finite numeric vectors, and an identifier (\code{id}), typically as returned from \code{\link{find_possible_distributions}}. Density plots require at least two distinct responses in each distribution.}
 
 \item{plot_type}{Plot multiple histograms, or overlapping cumulative distribution plots, or density plots? "auto" is to plot histograms if up to 9 distributions are passed, or if there are fewer than 10 discrete values, and empirical cumulative distribution plots otherwise}
 
-\item{max_plots}{How many distributions should \emph{at most} be plotted? If more are passed, this number is randomly selected.}
+\item{max_plots}{Positive integer: how many distributions should \emph{at most} be plotted? If more are passed, this number is randomly selected.}
 
 \item{show_ids}{Should ids of the distributions be shown with ecdf and density charts? Defaults to no, since the default ids are not meaningful.}
 
@@ -30,6 +30,13 @@ A ggplot2 object that can be styled with functions such as \code{\link[ggplot2]{
 This plots distributions identified by \code{\link{find_possible_distributions}} using ggplot2.
 They can be shown as histograms or as \href{https://towardsdatascience.com/what-why-and-how-to-read-empirical-cdf-123e2b922480}{cumulative distributions (ECDF) plots}. The latter give
 more information, yet not all audiences are familiar with them.
+}
+\details{
+Histograms show the exact frequency at each observed response. Bar widths
+use the response spacing (\code{1 / n_items}) for SPRITE results. For ordinary
+tibbles, widths use the smallest observed spacing, or 1 if all responses are
+identical. Scale endpoints and complete bars are retained. Empty inputs
+produce an informative error.
 }
 \examples{
 sprite_parameters <- set_parameters(mean = 2.2, sd = 1.3, n_obs = 20,

--- a/tests/testthat/test-core-and-plot-functions.R
+++ b/tests/testthat/test-core-and-plot-functions.R
@@ -191,8 +191,8 @@ if (all(requireNamespace(req_packages, quietly = TRUE))) {
   p <- plot_distributions(poss)
 
   test_that("histograms are produced", {
-    expect_class(p$layers[[1]]$stat, "StatBin")
-    expect_identical(p$scales$scales[[1]]$limits, c(1, 5))
+    expect_class(p$layers[[1]]$stat, "StatCount")
+    expect_true(is.function(p$scales$scales[[1]]$limits))
     expect_identical(p$facet$params$nrow, 3)
   })
 }

--- a/tests/testthat/test-plot-regressions.R
+++ b/tests/testthat/test-plot-regressions.R
@@ -1,0 +1,88 @@
+plot_fixture <- function(values, n_items = NULL, min_val = 1, max_val = 5) {
+  d <- tibble::tibble(id = seq_along(values), distribution = values)
+  if (!is.null(n_items)) {
+    class(d) <- c("sprite_distributions", class(d))
+    attr(d, "parameters") <- list(n_items = n_items, min_val = min_val, max_val = max_val)
+  }
+  d
+}
+
+require_plot_packages <- function() {
+  for (pkg in c("ggplot2", "tidyr", "tibble", "rlang", "scales")) {
+    skip_if_not_installed(pkg)
+  }
+}
+
+draw_distribution_plot <- function(p) {
+  grDevices::pdf(file = NULL)
+  on.exit(grDevices::dev.off())
+  grid::grid.draw(ggplot2::ggplotGrob(p))
+}
+
+test_that("histogram bars preserve exact frequencies and complete endpoints", {
+  require_plot_packages()
+  cases <- list(
+    plot_fixture(list(c(rep(1, 3), rep(2, 3), rep(3, 4))), 1, 1, 3),
+    plot_fixture(list(c(1, 1, 2, 4, 5, 5)), 1),
+    plot_fixture(list(c(1, 4/3, 5/3, 2, 2, 10/3, 4, 5)), 3),
+    plot_fixture(list(rep(3, 10)), 1),
+    plot_fixture(list(rep(3, 10))),
+    plot_fixture(list(c(1, 2, 4), c(2, 4, 4, 5)), 1)
+  )
+  for (d in cases) {
+    p <- plot_distributions(d, "histogram")
+    built <- ggplot2::ggplot_build(p)
+    bars <- built$data[[1]]
+    expect_true(all(is.finite(bars$xmin)))
+    expect_true(all(is.finite(bars$xmax)))
+    expect_equal(sum(bars$count), sum(lengths(d$distribution)))
+    for (i in seq_along(d$distribution)) {
+      actual <- bars[as.integer(bars$PANEL) == i, ]
+      responses <- sort(unique(d$distribution[[i]]))
+      expect_equal(actual$x, responses)
+      expect_equal(actual$count, vapply(responses, function(x) sum(d$distribution[[i]] == x), integer(1)))
+    }
+    if (inherits(d, "sprite_distributions")) {
+      expect_equal(bars$xmax - bars$xmin,
+                   rep(0.9 / attr(d, "parameters")$n_items, nrow(bars)))
+    }
+    expect_no_warning(draw_distribution_plot(p))
+  }
+})
+
+test_that("empty and malformed plot inputs have deliberate diagnostics", {
+  require_plot_packages()
+  expect_error(plot_distributions(plot_fixture(list())), "No distributions to plot")
+  for (x in list(numeric(), c(1, NA), c(1, Inf), "1", factor(1), matrix(1:4, 2), list(1))) {
+    expect_error(plot_distributions(plot_fixture(list(x))), "nonempty, finite numeric vectors")
+  }
+  expect_error(plot_distributions(tibble::tibble(id = 1, distribution = 1)), "list-column")
+  for (x in list(NA, 0, -1, Inf, 1.5, c(1, 2), "2")) {
+    expect_error(plot_distributions(plot_fixture(list(1:3)), max_plots = x), "max_plots")
+  }
+  for (x in list(NA, 1, c(TRUE, FALSE), logical())) {
+    expect_error(plot_distributions(plot_fixture(list(1:3)), show_ids = x), "show_ids")
+    expect_error(plot_distributions(plot_fixture(list(1:3)), facets = x), "facets")
+  }
+  expect_error(plot_distributions(plot_fixture(list(1:3)), plot_type = c("ecdf", "density")), "plot_type")
+})
+
+test_that("constant ECDFs render and undefined densities are rejected", {
+  require_plot_packages()
+  d <- plot_fixture(list(rep(3, 10)))
+  expect_no_warning(draw_distribution_plot(plot_distributions(d, "ecdf")))
+  expect_error(plot_distributions(d, "density"), "at least two distinct")
+  expect_error(plot_distributions(plot_fixture(list(3)), "density"), "at least two distinct")
+  expect_no_warning(draw_distribution_plot(plot_distributions(plot_fixture(list(1:3)), "density")))
+})
+
+test_that("subsampling preserves the response lattice and frequency totals", {
+  require_plot_packages()
+  d <- plot_fixture(rep(list(c(1, 5/3, 5/3, 5)), 4), 3)
+  expect_message(p <- plot_distributions(d, max_plots = 2), "randomly selected")
+  bars <- ggplot2::ggplot_build(p)$data[[1]]
+  expect_equal(length(unique(bars$PANEL)), 2L)
+  expect_equal(sum(bars$count), 8)
+  expect_equal(bars$xmax - bars$xmin, rep(0.3, nrow(bars)))
+  expect_no_warning(draw_distribution_plot(p))
+})


### PR DESCRIPTION
Distribution plots could hide the minimum and maximum responses, merge different multi-item responses, and misrepresent gaps. Histogram plots now show one frequency bar per exact response, retain complete endpoint bars, and use the response lattice for bar width. NEWS and the help page describe the changes.

- Ordinary use: fixes missing endpoint bars and incorrect frequencies for single-item and multi-item scales, gaps, and constant distributions. An empty search result now gives an informative plotting error.
- Rare-input hardening: malformed hand-built distribution columns and non-scalar controls fail clearly. Density plots reject insufficient variation.

Validation: 126 assertions passed with no failures, warnings, or skips; regression tests draw the plots and check bar counts, positions, widths, facets, and subsampling. Representative plots were rendered and visually inspected. R CMD check reported 0 errors and 0 warnings (the temporary worktree's `.git` file caused one packaging note).

`claude -p --model fable` reviewed the implementation and tests and reported no confirmed findings. A harmless redundant plot assignment noted in review was removed, then the full suite passed again.

Coverage: Astra F01/F16 and plotting validation in F11; Fable 6/13 and the plotting dependency check in 22. [Astra report](https://rsprite2-audit-astra-2026-09-09.surge.sh/), [Fable report](https://rsprite2-audit.surge.sh/). Changes are confined to rsprite2.
