### PR TITLE
Correct precision, GRIMMER screening, and statistical return contracts

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,8 +1,23 @@
 # rsprite2 0.2.1.9002
 
-* Maintenance: fixed workflow syntax and enabled package checks on pull requests. Documentation is committed only after successful checks on branch pushes. These changes improve release checks and do not alter statistical results.
-* Ordinary use: fixed distribution plots to retain complete endpoint bars and show exact response frequencies, including multi-item scales, gaps, and constant distributions. Empty search results now produce a clear plotting diagnostic.
-* Rare-input hardening: for manually supplied data, invalid distribution vectors and scalar controls now produce clear errors; density plots reject distributions with fewer than two distinct responses.
+## Fixes affecting ordinary use
+
+* Fixed distribution plots to retain complete endpoint bars and show exact response frequencies, including multi-item scales, gaps, and constant distributions. Empty search results now produce a clear plotting diagnostic.
+* Corrected inferred precision for negative numbers and scientific notation, and infer SD precision from the SD in boundary checks. Rounded zero SDs and multi-item constant samples now pass GRIMMER when compatible. Floating-point tolerance also prevents false rejection at sum-of-squares boundaries on ordinary multi-item scales.
+* GRIMMER now consistently honours its return modes and returns compatible SD candidates for the tested interval. Empty candidate vectors always indicate failure. Added `quiet` controls and clarified that passing this screening test does not prove that a sample exists.
+* Corrected GRIM's nearest reported means, including ties, and avoid enumerating candidates for logical-only GRIM checks.
+
+## Edge cases and input hardening
+
+* For manually supplied data, invalid distribution vectors and scalar controls now produce clear errors; density plots reject distributions with fewer than two distinct responses.
+* Stabilised SD bounds and GRIMMER calculations for scales with unusually large offsets.
+* Validate finite statistics, positive counts, scalar flags, explicit precisions, and ordered integer scale bounds. Undefined boundary ranges consistently return two numeric missing values when requested. Extremely large arithmetic or candidate enumerations now fail explicitly.
+
+## Maintenance
+
+* Fixed workflow syntax and enabled package checks on pull requests. Documentation is committed only after successful checks on branch pushes. These changes improve release checks and do not alter statistical results.
+
+## Earlier development changes
 
 * Changed implementation of `GRIM_test()` to more direct calculation rather than iterative check to increase transparency and efficiency. If requested to return the nearest possible means, the function now also correctly returns two values if there are two equidistant values. (For users wishing to use the original algorithm, it is presently retained as an *unexported* function that can be called with `rsprite2:::GRIM_test_old()`.)
 * Changed implementation of `GRIMMER_test()` to account for the fact that multiple exact means may be compatible with the reported means, if the mean is reported to a lower precision than the standard deviation. The previous version missed some valid SDs in this rare case. Also optimised the implementation of the algorithm to catch special cases explicitly and run a lot faster.

--- a/R/core-functions.R
+++ b/R/core-functions.R
@@ -862,8 +862,9 @@ boundary_test <- function(sd, n_obs, mean, min_val, max_val,
 #'
 #' @details
 #' GRIMMER compatibility is a necessary condition for a sample to exist, not
-#' proof that a sample exists. The integer and parity conditions on sums of
-#' squares can pass even when no sample produces the reported statistics.
+#' proof that a sample exists. The integer, parity, and minimum-variance
+#' conditions on sums of squares can pass even when no sample produces the
+#' reported statistics.
 #' Optional scale bounds add a range check but do not make the test sufficient.
 #' For example, two integer observations on a scale from 0 to 4 cannot have
 #' mean 2 and SD 2.0, although these statistics pass GRIMMER.
@@ -951,6 +952,12 @@ GRIMMER_test <- function(mean, sd, n_obs, m_prec = NULL, sd_prec = NULL,
     tolerance <- max(rSprite.dust, 8 * .Machine$double.eps * max(lower_ss, upper_ss))
     lower <- ceiling(lower_ss - tolerance)
     upper <- floor(upper_ss + tolerance)
+    # For this total, adjacent integer item sums give the smallest possible
+    # sum of squares. This also rules out zero SD for off-lattice means.
+    q <- floor(total / n_obs)
+    k <- total - q * n_obs
+    minimum_ss <- (n_obs - k) * q^2 + k * (q + 1)^2
+    lower <- max(lower, minimum_ss)
     lower <- lower + ((round(total) - lower) %% 2)
     if (lower > upper) next
     # Apply the same SD rounding check in every return mode. At an integer

--- a/R/core-functions.R
+++ b/R/core-functions.R
@@ -597,6 +597,11 @@ find_possible_distribution <- function(parameters, seed = NULL, values_only = FA
 #'   and a numeric vector `values` containing the relevant means.
 #' @param quiet Suppress warnings.
 #'
+#' @details Logical-only requests compare interval endpoints without enumerating
+#'   possible means. Value and list requests stop if more than one million
+#'   candidates would need enumeration. Inputs beyond reliable integer
+#'   arithmetic also stop with an informative error.
+#'
 #' @return The return type depends on the arguments. By default, a logical scalar
 #'   (`TRUE` or `FALSE`). If `return_values = TRUE`, a numeric vector is returned.
 #'   If `return_list = TRUE`, a list is returned.
@@ -618,83 +623,44 @@ find_possible_distribution <- function(parameters, seed = NULL, values_only = FA
 
 GRIM_test <- function(mean, n_obs, m_prec = NULL, n_items = 1,
                       return_values = FALSE, return_list = FALSE, quiet = FALSE) {
-
-  # --- Parameter validation and setup ---
-  if (is.null(m_prec)) {
-    m_prec <- max(nchar(sub("^[0-9]*", "", mean)) - 1, 0)
-  }
-
-  assert_count(m_prec)
-  assert_count(n_obs)
-  assert_count(n_items)
-  assert_logical(return_values)
-  assert_logical(return_list)
-  assert_number(mean)
-
+  assert_number(mean, finite = TRUE)
+  assert_count(n_obs, positive = TRUE)
+  assert_count(n_items, positive = TRUE)
+  assert_flag(return_values)
+  assert_flag(return_list)
+  assert_flag(quiet)
+  if (is.null(m_prec)) m_prec <- .infer_prec(mean)
+  .assert_reported(mean, m_prec, "mean")
   effective_n <- n_obs * n_items
+  .assert_exact_integer(c(effective_n, mean * effective_n))
 
-  if (effective_n > 10^m_prec & !quiet) {
+  if (effective_n > 10^m_prec && !quiet) {
     warning("The sample size (* number of items) is too big compared to the precision of the reported mean. The GRIM test is only meaningful when N < 10 ^ precision (e.g. N < 100 for single-items means reported to two decimal places).")
   }
 
-  # --- Direct calculation of all possible integer sums ---
-  granule_mean <- 0.5 * 10^-m_prec
-  sum_lower_bound <- (mean - granule_mean - rSprite.dust) * effective_n
-  sum_upper_bound <- (mean + granule_mean + rSprite.dust) * effective_n
+  offset <- floor(mean)
+  centred_mean <- round(mean - offset, m_prec)
+  half_step <- 0.5 * 10^-m_prec
+  lower <- ceiling((centred_mean - half_step - rSprite.dust) * effective_n)
+  upper <- floor((centred_mean + half_step + rSprite.dust) * effective_n)
+  .assert_exact_integer(c(lower, upper))
+  passed <- lower <= upper
+  if (!return_values && !return_list) return(passed)
 
-  final_lower <- ceiling(sum_lower_bound)
-  final_upper <- floor(sum_upper_bound)
-
-  possible_realsums <- if (final_lower > final_upper) {
-    numeric(0)
+  if (passed) {
+    values <- offset + .integer_sequence(lower, upper) / effective_n
   } else {
-    final_lower:final_upper
-  }
-
-  test_passed <- length(possible_realsums) > 0
-
-  output_values <- if (!test_passed & (return_values | return_list)) {
-    # Test failed: determine the closest mean(s)
-    ideal_sum <- mean * effective_n
-    if (abs((ideal_sum %% 1) - 0.5) < rSprite.dust) {
-      # Equidistant case: two closest sums
-      lower_int <- floor(ideal_sum)
-      upper_int <- ceiling(ideal_sum)
-      round(c(lower_int / effective_n, upper_int / effective_n), m_prec)
-    } else {
-      # Standard case: one closest sum
-      int <- round(ideal_sum)
-      round(int / effective_n, m_prec)
-    }
-  } else {
-    # Test passed: all possible means
-    possible_realsums / effective_n
-  }
-
-  # --- Format output based on arguments ---
-
-  if (return_list) {
-    return(list(passed = test_passed, values = output_values))
-  }
-
-  if (!return_values) {
-    return(test_passed)
-  }
-
-  # For user calls requesting values: issue warnings on failure
-  if (!test_passed) {
-    prec_format <- paste("%.", m_prec, "f", sep = "")
-    if (length(output_values) > 1 & !quiet) {
-      warning("Mean ", sprintf(prec_format, mean), " fails GRIM test. Two equally close consistent values exist: ",
-              sprintf(prec_format, output_values[1]), " and ", sprintf(prec_format, output_values[2]))
-    } else {
-      if (!quiet)
-         warning("Mean ", sprintf(prec_format, mean), " fails GRIM test - closest consistent value: ",
-                 sprintf(prec_format, output_values))
+    neighbours <- c(floor(centred_mean * effective_n), ceiling(centred_mean * effective_n)) / effective_n
+    candidates <- sort(unique(c(round_down(neighbours, m_prec), round_up(neighbours, m_prec))))
+    distances <- abs(candidates - centred_mean)
+    values <- offset + candidates[abs(distances - min(distances)) < rSprite.dust]
+    if (!quiet && !return_list) {
+      warning("Mean ", mean, " fails GRIM test - closest consistent value(s): ",
+              paste(values, collapse = ", "))
     }
   }
-
-  return(output_values)
+  if (return_list) return(list(passed = passed, values = values))
+  values
 }
 
 GRIM_test_old <- function(mean, n_obs, m_prec = NULL, n_items = 1, return_values = FALSE, ...) {
@@ -702,14 +668,14 @@ GRIM_test_old <- function(mean, n_obs, m_prec = NULL, n_items = 1, return_values
   if ("return_list" %in% names(list(...))) stop("`return_list` argument is only implemented in the new `GRIM_test` function.")
 
   if (is.null(m_prec)) {
-    m_prec <- max(nchar(sub("^[0-9]*", "", mean)) - 1, 0)
+    m_prec <- .infer_prec(mean)
   }
 
   assert_count(m_prec)
-  assert_count(n_obs)
-  assert_count(n_items)
-  assert_logical(return_values)
-  assert_number(mean)
+  assert_count(n_obs, positive = TRUE)
+  assert_count(n_items, positive = TRUE)
+  assert_flag(return_values)
+  assert_number(mean, finite = TRUE)
 
   if (n_obs * n_items > 10 ^ m_prec) {
     warning("The sample size (x number of items) is too big compared to the precision of the reported mean. The GRIM test is only meaningful when N < 10 ^ precision (e.g. N < 100 for means reported to two decimal places).")
@@ -775,92 +741,48 @@ round_up <- function(number, decimals, tolerance = rSprite.dust) {
 
 # Closed-interval SD limits --------------------------------------------
 .sd_limits <- function(n_obs, mean, min_val, max_val,
-                          m_prec = NULL, sd_prec = NULL,
-                          n_items = 1, quiet = FALSE,
-                          tol = rSprite.dust) {
-
-  if (!GRIM_test(mean, n_obs, m_prec = m_prec,
-                 n_items = n_items, quiet = quiet)) {
-    warning("`GRIM_test` failed, so no range for SDs can be calculated.")
+                       m_prec = NULL, sd_prec = NULL,
+                       n_items = 1, quiet = FALSE, tol = rSprite.dust) {
+  if (is.null(m_prec)) m_prec <- .infer_prec(mean)
+  if (is.null(sd_prec)) sd_prec <- m_prec
+  if (!GRIM_test(mean, n_obs, m_prec, n_items, quiet = quiet)) {
+    if (!quiet) warning("`GRIM_test` failed, so no range for SDs can be calculated.")
+    return(c(NA_real_, NA_real_))
+  }
+  if (n_obs == 1) {
+    if (!quiet) warning("SD undefined for single observation")
     return(c(NA_real_, NA_real_))
   }
 
-  if (is.null(m_prec))  m_prec  <- max(nchar(sub("^[0-9]*", "", mean)) - 1, 0)
-  if (is.null(sd_prec)) sd_prec <- max(nchar(sub("^[0-9]*", "", mean)) - 1, 0)
-  if (min_val == max_val) return(c(0, 0))
-  if (n_obs == 1) {
-    warning("SD undefined for single observation")
-    return(c(NA, NA))
-  }
+  # Translate the scale before taking squares, preserving the integer lattice.
+  width <- (max_val - min_val) * n_items
+  centre <- round(mean - min_val, m_prec) * n_obs * n_items
+  radius <- (0.5 * 10^-m_prec + tol) * n_obs * n_items
+  .assert_exact_integer(c(width, n_obs * width, centre))
+  totals <- .integer_sequence(max(0, ceiling(centre - radius)),
+                             min(n_obs * width, floor(centre + radius)))
+  if (!length(totals)) return(c(NA_real_, NA_real_))
+  if (width == 0) return(c(0, 0))
 
-  half_step <- 0.5 * 10^-m_prec
-  S         <- n_obs * n_items
-  totals    <- seq(ceiling((mean - half_step - tol) * S),
-                   floor  ((mean + half_step + tol) * S))
-
-  total_scores <- totals / n_items
-  mu_vec       <- total_scores / n_obs
-
-  ## minimise SD --------------------------------------------------------
-  a_min  <- floor(mu_vec * n_items) / n_items
-  b_min  <- pmin(a_min + 1 / n_items, max_val)
-
-  same_ab_min <- abs(a_min - b_min) < tol
-  k_raw_min <- ifelse(same_ab_min, 0, (total_scores - n_obs * b_min) / (a_min - b_min))
-  k_int_min   <- round(k_raw_min)
-
-  ok_min <- !same_ab_min &                      # integer count
-    abs(k_raw_min - k_int_min) < tol &
-    k_int_min >= 0 & k_int_min <= n_obs
-
-  ss_min <- rep(NA_real_, length(totals))       # NA for impossible totals
-  ss_min[same_ab_min] <- n_obs * a_min[same_ab_min]^2
-  ss_min[ok_min]      <- k_int_min[ok_min]           * a_min[ok_min]^2 +
-    (n_obs - k_int_min[ok_min]) * b_min[ok_min]^2
-
-
-  ## maximise SD --------------------------------------------------------
-  a_max <- min_val
-  b_max <- max_val
-
-  k_raw_max <- (total_scores - n_obs * b_max) / (a_max - b_max)
-  k_int_max <- round(k_raw_max)
-  diff_max  <- total_scores - (k_int_max * a_max +
-                                 (n_obs - k_int_max) * b_max)
-  valid_exact <- abs(diff_max) < tol &
-    k_int_max >= 0 & k_int_max <= n_obs
-
-  step      <- 1 / n_items
-  can_patch <- !valid_exact &
-    abs(diff_max) <= (b_max - a_max) &
-    abs(diff_max / step - round(diff_max / step)) < tol &
-    k_int_max >= 0 & k_int_max <= n_obs
-
-  replacement <- ifelse(diff_max > 0,
-                        a_max + diff_max,
-                        b_max + diff_max)           # only used when can_patch
-
-  base_ss <- k_int_max * a_max^2 + (n_obs - k_int_max) * b_max^2
-  patch_ss <- base_ss -
-    ifelse(diff_max > 0, a_max^2, b_max^2) +
-    replacement^2
-
-  ss_max <- ifelse(valid_exact, base_ss,
-                   ifelse(can_patch, patch_ss, NA_real_))
-
-  ## variance & SD ------------------------------------------------------
-  var_from_ss <- function(ss, sum_scores, n)
-    pmax((ss - sum_scores^2 / n) / (n - 1), 0)
-
-  min_sd <- sqrt(min(var_from_ss(ss_min,  total_scores, n_obs), na.rm = TRUE))
-  max_sd <- sqrt(max(var_from_ss(ss_max,  total_scores, n_obs), na.rm = TRUE))
-
-  if (is.infinite(min_sd) || is.infinite(max_sd)) {
+  # A minimum-variance sample uses adjacent lattice points. A maximum uses
+  # the endpoints with at most one interior response. Centre each expression
+  # on its exact mean to avoid subtracting nearly equal sums of squares.
+  k <- totals %% n_obs
+  minimum_variance <- k * (n_obs - k) / n_obs / (n_obs - 1) / n_items^2
+  high_count <- floor(totals / width)
+  remainder <- totals - high_count * width
+  interior_count <- as.numeric(remainder > 0)
+  low_count <- n_obs - high_count - interior_count
+  exact_mean <- totals / n_obs
+  maximum_variance <- (high_count * (width - exact_mean)^2 +
+    low_count * exact_mean^2 + interior_count * (remainder - exact_mean)^2) /
+    (n_obs - 1) / n_items^2
+  limits <- c(sqrt(min(minimum_variance)), sqrt(max(maximum_variance)))
+  if (any(!is.finite(limits))) {
     if (!quiet) warning("Error in calculating range of possible standard deviations.")
     return(c(NA_real_, NA_real_))
   }
-
-  c(round_down(min_sd, sd_prec), round_up(max_sd, sd_prec))
+  c(round_down(limits[1], sd_prec), round_up(limits[2], sd_prec))
 }
 
 #' Boundary test for standard deviation
@@ -873,11 +795,14 @@ round_up <- function(number, decimals, tolerance = rSprite.dust) {
 #' precision of the reported SD, this should only be a precursor to `GRIMMER_test()`
 #'
 #' @inheritParams set_parameters
+#' @param quiet Suppress warnings.
 #' @param return_range (Optional) If `TRUE`, the function returns a numeric vector with the SD possible range.
 #'
 #' @return Logical `TRUE` if the standard deviation is within the possible
 #'   range, and `FALSE` otherwise, unless `return_range`, in which case a
 #'   numeric vector with the lower and upper bounds of the possible SD range is returned.
+#'   If the range is undefined, `return_range = TRUE` returns two numeric `NA` values.
+#'   Scale endpoints must be integers; multi-item averages have spacing `1 / n_items`.
 #' @export
 #'
 #' @examples
@@ -888,47 +813,33 @@ round_up <- function(number, decimals, tolerance = rSprite.dust) {
 #' boundary_test(sd = 3.5, n_obs = 20, mean = 4, min_val = 1, max_val = 7)
 
 boundary_test <- function(sd, n_obs, mean, min_val, max_val,
-                          m_prec = NULL, sd_prec = NULL, n_items = 1, return_range = FALSE) {
-
-  # --- Input validation ---
-  assert_number(sd, lower = 0)
+                          m_prec = NULL, sd_prec = NULL, n_items = 1,
+                          return_range = FALSE, quiet = FALSE) {
+  assert_number(sd, lower = 0, finite = TRUE)
   assert_count(n_obs, positive = TRUE)
-  assert_number(mean)
-  assert_number(min_val)
-  assert_number(max_val)
-  assert_count(sd_prec, null.ok = TRUE)
+  assert_number(mean, finite = TRUE)
+  assert_int(min_val)
+  assert_int(max_val, lower = min_val)
   assert_count(n_items, positive = TRUE)
-  assert_logical(return_range)
+  assert_flag(return_range)
+  assert_flag(quiet)
+  if (is.null(m_prec)) m_prec <- .infer_prec(mean)
+  if (is.null(sd_prec)) sd_prec <- .infer_prec(sd)
+  .assert_reported(mean, m_prec, "mean")
+  .assert_reported(sd, sd_prec, "sd")
 
   if (mean < min_val || mean > max_val) {
-    warning("The mean is outside the possible scale range (min_val to max_val).")
-    return(FALSE)
+    if (!quiet) warning("The mean is outside the possible scale range (min_val to max_val).")
+    return(if (return_range) c(NA_real_, NA_real_) else FALSE)
   }
-
-  # --- Calculate the possible SD range ---
-  sd_range <- .sd_limits(
-    n_obs = n_obs,
-    mean = mean,
-    min_val = min_val,
-    max_val = max_val,
-    m_prec = m_prec,
-    sd_prec = sd_prec,
-    n_items = n_items,
-    quiet = TRUE
-  )
-
-  # --- Check for errors during range calculation ---
-  if (anyNA(sd_range)) {
-    return(FALSE)
-  }
-
-  if (return_range) {
-    return(sd_range)
-  }
-
-  # --- Perform the boundary test ---
-  (sd >= (sd_range[1] - rSprite.dust)) && (sd <= (sd_range[2] + rSprite.dust))
-
+  # Internal calls suppress the low-information granularity warning; failures
+  # still receive a public diagnostic unless the caller requests quiet output.
+  sd_range <- .sd_limits(n_obs, mean, min_val, max_val, m_prec, sd_prec,
+                         n_items, quiet = TRUE)
+  if (anyNA(sd_range) && !quiet) warning("No SD range is defined for the supplied mean and sample size.")
+  if (return_range) return(sd_range)
+  if (anyNA(sd_range)) return(FALSE)
+  sd >= sd_range[1] - rSprite.dust && sd <= sd_range[2] + rSprite.dust
 }
 
 #' GRIMMER test for standard deviation
@@ -942,20 +853,32 @@ boundary_test <- function(sd, n_obs, mean, min_val, max_val,
 #' @inheritParams set_parameters
 #' @param min_val (Optional) Scale minimum. If provided alongside max_val, the function checks whether the SD is consistent with that range.
 #' @param max_val (Optional) Scale maximum.
-#' @param return_values A logical value. *Ignored if `return_list = TRUE`*.
-#'  If `FALSE` (the default), the function returns a simple `TRUE` or `FALSE`. If `TRUE`, it returns a numeric
-#'  vector of all possible unrounded standard deviations that are consistent - unless the precision/sample size ratio
-#'  allows for all standard deviations within the possible range to be GRIMMER-consistent. In that case, a message
-#'  is shown and an empty numeric vector is returned.
-#' @param return_list A logical value. If `FALSE` (the default), the function's
-#'  return type is determined by `return_values`. If `TRUE`, the function
-#'  instead returns a list containing a logical `passed` flag
-#'  and a numeric `values` vector.
+#' @param return_values A logical value, ignored if `return_list = TRUE`.
+#'   If `TRUE`, return the unrounded SDs within the tested rounding interval
+#'   that satisfy the GRIMMER arithmetic conditions. Otherwise return a logical verdict.
+#' @param return_list If `TRUE`, return a list with logical `passed` and numeric
+#'   `values` components, irrespective of `return_values`.
+#' @param quiet Suppress warnings.
 #'
-#' @return The return type depends on the arguments. By default, a logical scalar
-#'  (`TRUE` or `FALSE`). If `return_values = TRUE`, a numeric vector is returned.
-#'  If `return_list = TRUE`, a list is returned. An inconsistent result will yield
-#'  `FALSE`, an empty numeric vector, or a list with `passed = FALSE`.
+#' @details
+#' GRIMMER compatibility is a necessary condition for a sample to exist, not
+#' proof that a sample exists. The integer and parity conditions on sums of
+#' squares can pass even when no sample produces the reported statistics.
+#' Optional scale bounds add a range check but do not make the test sufficient.
+#' For example, two integer observations on a scale from 0 to 4 cannot have
+#' mean 2 and SD 2.0, although these statistics pass GRIMMER.
+#'
+#' Both endpoints of each reporting interval are accepted to accommodate
+#' different conventions for rounding ties. A reported SD of zero therefore
+#' also includes small positive SDs that round to zero.
+#'
+#' @return A logical scalar by default. With `return_values = TRUE`, a numeric
+#'   vector of compatible unrounded SDs; an empty vector always means failure.
+#'   With `return_list = TRUE`, a list with `passed` and `values` components.
+#'   Candidate values satisfy the screening conditions and need not correspond
+#'   to actual samples. Requests requiring more than one million candidates
+#'   to be enumerated, or inputs beyond reliable integer arithmetic, stop
+#'   with an informative error.
 #' @export
 #'
 #' @examples
@@ -971,127 +894,79 @@ boundary_test <- function(sd, n_obs, mean, min_val, max_val,
 
 GRIMMER_test <- function(mean, sd, n_obs, m_prec = NULL, sd_prec = NULL,
                          n_items = 1, min_val = NULL, max_val = NULL,
-                         return_values = FALSE, return_list = FALSE) {
-
-  # --- Step 0: Input Validation and Edge Cases ---
+                         return_values = FALSE, return_list = FALSE, quiet = FALSE) {
+  assert_number(mean, finite = TRUE)
+  assert_number(sd, lower = 0, finite = TRUE)
+  assert_count(n_obs, positive = TRUE)
+  assert_count(n_items, positive = TRUE)
   assert_int(min_val, null.ok = TRUE)
   assert_int(max_val, null.ok = TRUE)
-  assert_count(m_prec, null.ok = TRUE)
-  assert_count(sd_prec, null.ok = TRUE)
-  assert_count(n_obs)
-  assert_count(n_items)
-  assert_number(mean)
-  assert_number(sd)
+  if (xor(is.null(min_val), is.null(max_val))) stop("Supply both `min_val` and `max_val`, or neither.")
+  if (!is.null(min_val)) assert_int(max_val, lower = min_val)
+  assert_flag(return_values)
+  assert_flag(return_list)
+  assert_flag(quiet)
+  if (is.null(m_prec)) m_prec <- .infer_prec(mean)
+  if (is.null(sd_prec)) sd_prec <- .infer_prec(sd)
+  .assert_reported(mean, m_prec, "mean")
+  .assert_reported(sd, sd_prec, "sd")
 
-  if (n_obs < 2) {
-    warning("With a single observation, SD is undefined. Returning FALSE.")
-    if (return_list) return(list(passed = FALSE, values = numeric(0)))
-    return(if (return_values) numeric(0) else FALSE)
+  result <- function(passed, values = numeric(0)) {
+    if (return_list) return(list(passed = passed, values = values))
+    if (return_values) return(values)
+    passed
+  }
+  if (n_obs == 1) {
+    if (!quiet) warning("With a single observation, SD is undefined. Returning FALSE.")
+    return(result(FALSE))
+  }
+  if (!GRIM_test(mean, n_obs, m_prec, n_items, quiet = quiet)) {
+    if (!quiet) warning("GRIM test failed - so GRIMMER also fails.")
+    return(result(FALSE))
+  }
+  if (!is.null(min_val) && !boundary_test(sd, n_obs, mean, min_val, max_val,
+                                        m_prec, sd_prec, n_items, quiet = TRUE)) {
+    return(result(FALSE))
   }
 
-  # --- Step 1a: Call GRIM_test to check and get possible means ---
-  grim_result <- GRIM_test(mean = mean, n_obs = n_obs, m_prec = m_prec, n_items = n_items, return_list = TRUE)
-
-  if (!grim_result$passed) {
-    warning("GRIM test failed - so GRIMMER also fails.")
-    if (return_list) return(list(passed = FALSE, values = numeric(0)))
-    return(if (return_values) numeric(0) else FALSE)
-  }
-
-  possible_means <- grim_result$values
-
-  # --- Step 1b: Call boundary_test to see whether mean and SD are within possible range (if range is provided)
-  if (!is.null(min_val) && !is.null(max_val) &&
-    !boundary_test(sd = sd, n_obs = n_obs, mean = mean, min_val = min_val,
-                     max_val = max_val, m_prec = m_prec, sd_prec = sd_prec, n_items = n_items)) {
-    return(FALSE)
-  }
-
-  # --- Step 2: Setup (constants, helpers, boundary checks) ---
-  if (is.null(sd_prec)) {
-    sd_prec <- max(nchar(sub("^[0-9]*", "", as.character(sd))) - 1, 0)
-  }
-
+  # Subtract an integer response offset before computing sums of squares.
+  # Integer translation preserves the parity constraint and avoids cancellation
+  # when the input scale has a large offset.
+  offset <- floor(mean)
+  centred_mean <- round(mean - offset, m_prec)
   effective_n <- n_obs * n_items
-
-  granule_sd <- 5 / (10^(sd_prec + 1))
-  Lsigma <- ifelse(sd < granule_sd, 0, sd - granule_sd)
-  Usigma <- sd + granule_sd
-
-  test_passed <- FALSE
-  consistent_sds <- numeric(0)
-
-  # Check if the SD is zero, which is a special case
-  .on_lattice <- function(mean, n_items, tol = rSprite.dust) {
-    abs(mean * n_items - round(mean * n_items)) < tol
+  half_mean <- 0.5 * 10^-m_prec + rSprite.dust
+  totals <- .integer_sequence(ceiling((centred_mean - half_mean) * effective_n),
+                              floor((centred_mean + half_mean) * effective_n))
+  half_sd <- 0.5 * 10^-sd_prec
+  lower_sd <- max(0, sd - half_sd)
+  upper_sd <- sd + half_sd
+  values <- numeric(0)
+  for (total in totals) {
+    squared_mean <- total^2 / n_obs
+    lower_ss <- (n_obs - 1) * (lower_sd * n_items)^2 + squared_mean
+    upper_ss <- (n_obs - 1) * (upper_sd * n_items)^2 + squared_mean
+    .assert_exact_integer(c(total, lower_ss, upper_ss))
+    tolerance <- max(rSprite.dust, 8 * .Machine$double.eps * max(lower_ss, upper_ss))
+    lower <- ceiling(lower_ss - tolerance)
+    upper <- floor(upper_ss + tolerance)
+    lower <- lower + ((round(total) - lower) %% 2)
+    if (lower > upper) next
+    # Apply the same SD rounding check in every return mode. At an integer
+    # boundary, the sum-of-squares tolerance can include a candidate just
+    # outside the SD interval, particularly when the SD is close to zero.
+    first_sd <- sqrt(max(0, (lower - squared_mean) / (n_obs - 1))) / n_items
+    if (first_sd < lower_sd - rSprite.dust) lower <- lower + 2
+    if (lower > upper) next
+    first_sd <- sqrt(max(0, (lower - squared_mean) / (n_obs - 1))) / n_items
+    if (!.rounding_compatible(first_sd, sd, sd_prec)) next
+    if (!return_values && !return_list) return(result(TRUE))
+    sums_of_squares <- .integer_sequence(lower, upper, by = 2)
+    candidate_sd <- sqrt(pmax(0, (sums_of_squares - squared_mean) /
+                                  (n_obs - 1))) / n_items
+    matches <- .rounding_compatible(candidate_sd, sd, sd_prec)
+    values <- c(values, candidate_sd[matches])
   }
-
-
-  if (.equalish(sd, 0)) {
-    valid_zero <- .on_lattice(mean, n_items)
-    if (!valid_zero) {
-      warning("SD of 0 is not possible with the given mean and number of items.")
-      if (return_list) return(list(passed = valid_zero, values = numeric(0)))
-      return(valid_zero)
-    } else {
-    if (return_list) return(list(passed = valid_zero, values = 0))
-    return(valid_zero)
-  }
-  }
-
-
-  # --- Step 3: Loop through each valid mean ---
-  for (realmean in possible_means) {
-    realsum <- realmean * effective_n
-    lower_bound_ss <- ((n_obs - 1) * Lsigma^2 + n_obs * realmean^2) * n_items^2
-    upper_bound_ss <- ((n_obs - 1) * Usigma^2 + n_obs * realmean^2) * n_items^2
-
-    if (ceiling(lower_bound_ss) > floor(upper_bound_ss)) next
-
-    window <- floor(upper_bound_ss) - ceiling(lower_bound_ss)
-    if (window >= 1) {                   # at least one integer of each parity exists
-      if (return_list) return(list(passed = TRUE, values = numeric(0)))
-      if (return_values) {
-        sd_range <- boundary_test(sd = sd, n_obs = n_obs, mean = mean, min_val = min_val,
-                      max_val = max_val, m_prec = m_prec, sd_prec = sd_prec, n_items = n_items, return_range = TRUE)
-        message("With the given precision, any SD within the range [", sd_range[1], ", ", sd_range[2], "] is GRIMMER compatible")
-        return(numeric(0))
-      }
-      return(TRUE)
-    }
-
-    possible_ss <- ceiling(lower_bound_ss):floor(upper_bound_ss)
-    possible_ss <- possible_ss[possible_ss %% 2 == round(realsum) %% 2] #round() used to remove floating point issues
-
-    if (length(possible_ss) == 0) next
-
-    Predicted_Variance <- (possible_ss / n_items^2 - n_obs * realmean^2) / (n_obs - 1)
-    Predicted_Variance[Predicted_Variance < 0] <- 0
-    Predicted_SD <- sqrt(Predicted_Variance)
-
-    matches <- .equalish(round_down(Predicted_SD, sd_prec), sd) | .equalish(round_up(Predicted_SD, sd_prec), sd)
-
-    if (any(matches)) {
-      test_passed <- TRUE
-      if (return_values || return_list) {
-        consistent_sds <- c(consistent_sds, Predicted_SD[matches])
-      } else {
-        return(TRUE)
-      }
-    }
-  }
-
-  # --- Step 4: Format and return output ---
-  output_values <- sort(unique(consistent_sds))
-
-  if (return_list) {
-    return(list(passed = test_passed, values = output_values))
-  }
-  if (return_values) {
-    return(output_values)
-  }
-
-  return(test_passed)
+  values <- sort(unique(values))
+  result(length(values) > 0, values)
 }
-
-

--- a/R/core-functions.R
+++ b/R/core-functions.R
@@ -941,7 +941,8 @@ GRIMMER_test <- function(mean, sd, n_obs, m_prec = NULL, sd_prec = NULL,
   half_sd <- 0.5 * 10^-sd_prec
   lower_sd <- max(0, sd - half_sd)
   upper_sd <- sd + half_sd
-  values <- numeric(0)
+  values <- list()
+  candidate_count <- 0
   for (total in totals) {
     squared_mean <- total^2 / n_obs
     lower_ss <- (n_obs - 1) * (lower_sd * n_items)^2 + squared_mean
@@ -961,12 +962,14 @@ GRIMMER_test <- function(mean, sd, n_obs, m_prec = NULL, sd_prec = NULL,
     first_sd <- sqrt(max(0, (lower - squared_mean) / (n_obs - 1))) / n_items
     if (!.rounding_compatible(first_sd, sd, sd_prec)) next
     if (!return_values && !return_list) return(result(TRUE))
+    candidate_count <- candidate_count + floor((upper - lower) / 2) + 1
+    .assert_candidate_count(candidate_count)
     sums_of_squares <- .integer_sequence(lower, upper, by = 2)
     candidate_sd <- sqrt(pmax(0, (sums_of_squares - squared_mean) /
                                   (n_obs - 1))) / n_items
     matches <- .rounding_compatible(candidate_sd, sd, sd_prec)
-    values <- c(values, candidate_sd[matches])
+    values[[length(values) + 1L]] <- candidate_sd[matches]
   }
-  values <- sort(unique(values))
+  values <- sort(unique(as.numeric(unlist(values, use.names = FALSE))))
   result(length(values) > 0, values)
 }

--- a/R/statistical-helpers.R
+++ b/R/statistical-helpers.R
@@ -30,7 +30,7 @@
 
 .integer_sequence <- function(lower, upper, by = 1) {
   if (lower > upper) return(numeric(0))
-  if ((upper - lower) / by > 1e6) {
+  if (floor((upper - lower) / by) + 1 > 1e6) {
     stop("More than one million candidates would need enumeration; increase the reported precision or request a logical GRIM result.", call. = FALSE)
   }
   seq(lower, upper, by = by)

--- a/R/statistical-helpers.R
+++ b/R/statistical-helpers.R
@@ -1,0 +1,37 @@
+# Decimal precision of the displayed numeric value; trailing zeroes require an
+# explicit precision because R numeric scalars do not retain them.
+.infer_prec <- function(x) {
+  assert_number(x, finite = TRUE)
+  value <- format(abs(x), scientific = FALSE, digits = 15, trim = TRUE)
+  if (!grepl(".", value, fixed = TRUE)) return(0L)
+  nchar(sub("^[^.]*\\.", "", value))
+}
+
+.rounding_compatible <- function(actual, reported, precision, tol = rSprite.dust) {
+  abs(actual - reported) <= 0.5 * 10^-precision +
+    pmax(tol, 4 * .Machine$double.eps * pmax(abs(actual), abs(reported)))
+}
+
+.assert_reported <- function(x, precision, name) {
+  assert_count(precision)
+  if (precision > 308) {
+    stop("`", name, "` precision must be at most 308 decimal places.", call. = FALSE)
+  }
+  if (abs(x - round(x, precision)) > max(rSprite.dust, abs(x) * .Machine$double.eps)) {
+    stop("`", name, "` has more decimal places than its specified precision.", call. = FALSE)
+  }
+}
+
+.assert_exact_integer <- function(x) {
+  if (any(!is.finite(x) | abs(x) > 2^52)) {
+    stop("The requested statistics exceed reliable integer arithmetic; reduce the scale or sample size.", call. = FALSE)
+  }
+}
+
+.integer_sequence <- function(lower, upper, by = 1) {
+  if (lower > upper) return(numeric(0))
+  if ((upper - lower) / by > 1e6) {
+    stop("More than one million candidates would need enumeration; increase the reported precision or request a logical GRIM result.", call. = FALSE)
+  }
+  seq(lower, upper, by = by)
+}

--- a/R/statistical-helpers.R
+++ b/R/statistical-helpers.R
@@ -30,8 +30,12 @@
 
 .integer_sequence <- function(lower, upper, by = 1) {
   if (lower > upper) return(numeric(0))
-  if (floor((upper - lower) / by) + 1 > 1e6) {
+  .assert_candidate_count(floor((upper - lower) / by) + 1)
+  seq(lower, upper, by = by)
+}
+
+.assert_candidate_count <- function(count) {
+  if (!is.finite(count) || count > 1e6) {
     stop("More than one million candidates would need enumeration; increase the reported precision or request a logical GRIM result.", call. = FALSE)
   }
-  seq(lower, upper, by = by)
 }

--- a/README.Rmd
+++ b/README.Rmd
@@ -28,6 +28,8 @@ For that, it implements the SPRITE algorithm proposed by [Heathers et al. (2018)
 
 The package also includes dedicated functions to run the GRIM and GRIMMER tests. `GRIM_test()` checks whether a reported mean based on integers is consistent with a given sample size, while `GRIMMER_test()` checks whether a reported standard deviation is consistent with a reported mean and sample size. They can help catch impossible distributions and reporting errors without running any simulations.
 
+Passing GRIMMER is necessary but does not prove that a sample with the reported statistics exists, even when scale bounds are supplied. A successfully reconstructed sample whose statistics and restrictions have been verified provides a witness of feasibility. Conversely, a failed SPRITE search does not prove impossibility, and the frequency with which SPRITE finds a distribution does not estimate the probability that it was the original sample.
+
 ## Installation
 
 rsprite2 can be installed from CRAN with:

--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ checks whether a reported standard deviation is consistent with a
 reported mean and sample size. They can help catch impossible
 distributions and reporting errors without running any simulations.
 
+Passing GRIMMER is necessary but does not prove that a sample with the reported statistics exists, even when scale bounds are supplied. A successfully reconstructed sample whose statistics and restrictions have been verified provides a witness of feasibility. Conversely, a failed SPRITE search does not prove impossibility, and the frequency with which SPRITE finds a distribution does not estimate the probability that it was the original sample.
+
 ## Installation
 
 rsprite2 can be installed from CRAN with:

--- a/man/GRIMMER_test.Rd
+++ b/man/GRIMMER_test.Rd
@@ -14,7 +14,8 @@ GRIMMER_test(
   min_val = NULL,
   max_val = NULL,
   return_values = FALSE,
-  return_list = FALSE
+  return_list = FALSE,
+  quiet = FALSE
 )
 }
 \arguments{
@@ -37,22 +38,23 @@ Defaults to 1, which represents any single-item measure.}
 
 \item{max_val}{(Optional) Scale maximum.}
 
-\item{return_values}{A logical value. \emph{Ignored if \code{return_list = TRUE}}.
-If \code{FALSE} (the default), the function returns a simple \code{TRUE} or \code{FALSE}. If \code{TRUE}, it returns a numeric
-vector of all possible unrounded standard deviations that are consistent - unless the precision/sample size ratio
-allows for all standard deviations within the possible range to be GRIMMER-consistent. In that case, a message
-is shown and an empty numeric vector is returned.}
+\item{return_values}{A logical value, ignored if \code{return_list = TRUE}.
+If \code{TRUE}, return the unrounded SDs within the tested rounding interval
+that satisfy the GRIMMER arithmetic conditions. Otherwise return a logical verdict.}
 
-\item{return_list}{A logical value. If \code{FALSE} (the default), the function's
-return type is determined by \code{return_values}. If \code{TRUE}, the function
-instead returns a list containing a logical \code{passed} flag
-and a numeric \code{values} vector.}
+\item{return_list}{If \code{TRUE}, return a list with logical \code{passed} and numeric
+\code{values} components, irrespective of \code{return_values}.}
+
+\item{quiet}{Suppress warnings.}
 }
 \value{
-The return type depends on the arguments. By default, a logical scalar
-(\code{TRUE} or \code{FALSE}). If \code{return_values = TRUE}, a numeric vector is returned.
-If \code{return_list = TRUE}, a list is returned. An inconsistent result will yield
-\code{FALSE}, an empty numeric vector, or a list with \code{passed = FALSE}.
+A logical scalar by default. With \code{return_values = TRUE}, a numeric
+vector of compatible unrounded SDs; an empty vector always means failure.
+With \code{return_list = TRUE}, a list with \code{passed} and \code{values} components.
+Candidate values satisfy the screening conditions and need not correspond
+to actual samples. Requests requiring more than one million candidates
+to be enumerated, or inputs beyond reliable integer arithmetic, stop
+with an informative error.
 }
 \description{
 This function tests whether a given standard deviation (with a specific precision)
@@ -60,6 +62,18 @@ can result from a sample of a given size based on integer responses to one or mo
 items. The test was first proposed by \href{https://peerj.com/preprints/2400/}{Anaya (2016)}; here, the algorithm
 developed by \href{https://aurelienallard.netlify.app/post/anaytic-grimmer-possibility-standard-deviations/}{Allard (2018)} is used,
 extended by Aurélien Allard to support multi-item scales.
+}
+\details{
+GRIMMER compatibility is a necessary condition for a sample to exist, not
+proof that a sample exists. The integer and parity conditions on sums of
+squares can pass even when no sample produces the reported statistics.
+Optional scale bounds add a range check but do not make the test sufficient.
+For example, two integer observations on a scale from 0 to 4 cannot have
+mean 2 and SD 2.0, although these statistics pass GRIMMER.
+
+Both endpoints of each reporting interval are accepted to accommodate
+different conventions for rounding ties. A reported SD of zero therefore
+also includes small positive SDs that round to zero.
 }
 \examples{
 # A sample of 18 integers with mean 3.44 cannot have an SD of 2.47.

--- a/man/GRIMMER_test.Rd
+++ b/man/GRIMMER_test.Rd
@@ -65,8 +65,9 @@ extended by Aurélien Allard to support multi-item scales.
 }
 \details{
 GRIMMER compatibility is a necessary condition for a sample to exist, not
-proof that a sample exists. The integer and parity conditions on sums of
-squares can pass even when no sample produces the reported statistics.
+proof that a sample exists. The integer, parity, and minimum-variance
+conditions on sums of squares can pass even when no sample produces the
+reported statistics.
 Optional scale bounds add a range check but do not make the test sufficient.
 For example, two integer observations on a scale from 0 to 4 cannot have
 mean 2 and SD 2.0, although these statistics pass GRIMMER.

--- a/man/GRIM_test.Rd
+++ b/man/GRIM_test.Rd
@@ -50,6 +50,12 @@ This function tests whether a given mean (with a specific precision) can
 result from a sample of a given size based on integer responses to one or more
 items. The test is based on Brown & Heathers (2017).
 }
+\details{
+Logical-only requests compare interval endpoints without enumerating
+possible means. Value and list requests stop if more than one million
+candidates would need enumeration. Inputs beyond reliable integer
+arithmetic also stop with an informative error.
+}
 \examples{
 # A sample of 28 integers cannot result in a mean of 5.19.
 GRIM_test(mean = 5.19, n_obs = 28)

--- a/man/boundary_test.Rd
+++ b/man/boundary_test.Rd
@@ -13,7 +13,8 @@ boundary_test(
   m_prec = NULL,
   sd_prec = NULL,
   n_items = 1,
-  return_range = FALSE
+  return_range = FALSE,
+  quiet = FALSE
 )
 }
 \arguments{
@@ -37,11 +38,15 @@ reported standard deviation ends in 0.}
 Defaults to 1, which represents any single-item measure.}
 
 \item{return_range}{(Optional) If \code{TRUE}, the function returns a numeric vector with the SD possible range.}
+
+\item{quiet}{Suppress warnings.}
 }
 \value{
 Logical \code{TRUE} if the standard deviation is within the possible
 range, and \code{FALSE} otherwise, unless \code{return_range}, in which case a
 numeric vector with the lower and upper bounds of the possible SD range is returned.
+If the range is undefined, \code{return_range = TRUE} returns two numeric \code{NA} values.
+Scale endpoints must be integers; multi-item averages have spacing \code{1 / n_items}.
 }
 \description{
 This function tests whether a given standard deviation is within the range that is

--- a/tests/testthat/test-core-and-plot-functions.R
+++ b/tests/testthat/test-core-and-plot-functions.R
@@ -63,7 +63,7 @@ test_that("GRIMMER works as expected", {
   # Returns list on success
   expect_equal(
     GRIMMER_test(5.21, 1.6, 28, return_list = TRUE),
-    list(passed = TRUE, values = numeric(0))
+    list(passed = TRUE, values = sqrt((seq(828, 834, 2) - 146^2 / 28) / 27))
   )
   # n_obs < 2 (SD is undefined)
   expect_warning(

--- a/tests/testthat/test-statistical-regressions.R
+++ b/tests/testthat/test-statistical-regressions.R
@@ -36,6 +36,21 @@ test_that("GRIMMER return modes agree including rounded zero and boundary failur
   expect_true(GRIMMER_test(1.83, .2, 9, n_items = 2, m_prec = 2, sd_prec = 1, quiet = TRUE))
 })
 
+test_that("GRIMMER rejects SDs below each total's lattice minimum", {
+  for (reported_mean in c(-1.5, 1.5, 1e8 + 1.5)) {
+    expect_false(GRIMMER_test(reported_mean, 0, 8, sd_prec = 2, quiet = TRUE))
+    expect_false(GRIMMER_test(reported_mean, 0, 8, sd_prec = 0, quiet = TRUE))
+    # Half-integer constants are available on a two-item lattice.
+    expect_true(GRIMMER_test(reported_mean, 0, 8, n_items = 2,
+                            sd_prec = 2, quiet = TRUE))
+  }
+  expect_false(GRIMMER_test(2.5, 0, 10, quiet = TRUE))
+  expect_false(GRIMMER_test(1.44, .17, 9, quiet = TRUE))
+  expect_false(GRIMMER_test(-1.44, .17, 9, quiet = TRUE))
+  # Rounded zero still includes genuine small positive SDs.
+  expect_true(GRIMMER_test(1.1, 0, 10, m_prec = 1, sd_prec = 0, quiet = TRUE))
+})
+
 test_that("statistical tests reject malformed inputs and preserve undefined range types", {
   for (bad in list(0, -1, NA_real_, Inf, 2.5)) {
     expect_error(GRIM_test(2, bad, quiet = TRUE))

--- a/tests/testthat/test-statistical-regressions.R
+++ b/tests/testthat/test-statistical-regressions.R
@@ -60,6 +60,8 @@ test_that("statistical tests reject malformed inputs and preserve undefined rang
   expect_no_warning(.sd_limits(1, 2, 1, 3, quiet = TRUE))
   expect_error(GRIM_test(1e16, 10, quiet = TRUE), "reliable integer arithmetic")
   expect_true(GRIM_test(2, 1e9, m_prec = 0, quiet = TRUE))
+  expect_error(GRIMMER_test(3.12, 1.53, 1e6, 2, 2, return_values = TRUE, quiet = TRUE),
+               "More than one million candidates")
 })
 
 test_that("SD tests are invariant to large integer translations", {

--- a/tests/testthat/test-statistical-regressions.R
+++ b/tests/testthat/test-statistical-regressions.R
@@ -1,0 +1,122 @@
+test_that("precision follows the reported statistic", {
+  expect_equal(vapply(c(-.55, -3, 1e-5, 1e5, .1 + .2, 123456.789), .infer_prec, 0L),
+               c(2, 0, 5, 0, 1, 3))
+  expect_true(GRIM_test(-1.3, 3))
+  expect_false(GRIM_test(1e-5, 10000, quiet = TRUE))
+  expect_true(boundary_test(.71, 2, 1.5, 1, 2))
+  expect_true(GRIMMER_test(1.5, .71, 2, min_val = 1, max_val = 2, quiet = TRUE))
+  expect_true(boundary_test(3.1, 10, 4, 1, 7))
+  expect_equal(GRIM_test(1.14, 8, return_values = TRUE, quiet = TRUE), 1.13)
+  expect_equal(GRIM_test(1.07, 7, return_values = TRUE, quiet = TRUE), c(1, 1.14))
+})
+
+test_that("GRIMMER return modes agree including rounded zero and boundary failures", {
+  cases <- list(
+    list(mean = 1.33, sd = 0, n_obs = 3, n_items = 3, m_prec = 2, sd_prec = 2),
+    list(mean = 1.1, sd = 0, n_obs = 10, m_prec = 1, sd_prec = 0),
+    list(mean = 2, sd = 0, n_obs = 10),
+    list(mean = 5.19, sd = 1.5, n_obs = 28),
+    list(mean = 2, sd = 5, n_obs = 10, min_val = 1, max_val = 3),
+    list(mean = 5.21, sd = 1.6, n_obs = 28),
+    list(mean = 3.44, sd = 2.47, n_obs = 18),
+    list(mean = 2, sd = 1, n_obs = 1)
+  )
+  for (args in cases) {
+    args$quiet <- TRUE
+    verdict <- do.call(GRIMMER_test, args)
+    values <- do.call(GRIMMER_test, c(args, list(return_values = TRUE)))
+    detailed <- do.call(GRIMMER_test, c(args, list(return_list = TRUE)))
+    expect_type(verdict, "logical")
+    expect_type(values, "double")
+    expect_identical(detailed, list(passed = verdict, values = values))
+    expect_identical(verdict, length(values) > 0)
+  }
+  expect_true(GRIMMER_test(1.33, 0, 3, n_items = 3, quiet = TRUE))
+  expect_true(GRIMMER_test(1.1, 0, 10, sd_prec = 0, quiet = TRUE))
+  expect_true(GRIMMER_test(1.83, .2, 9, n_items = 2, m_prec = 2, sd_prec = 1, quiet = TRUE))
+})
+
+test_that("statistical tests reject malformed inputs and preserve undefined range types", {
+  for (bad in list(0, -1, NA_real_, Inf, 2.5)) {
+    expect_error(GRIM_test(2, bad, quiet = TRUE))
+    expect_error(GRIMMER_test(2, 1, 10, n_items = bad, quiet = TRUE))
+  }
+  for (bad in list(NA, c(TRUE, FALSE), 1)) {
+    expect_error(GRIM_test(2, 10, return_values = bad))
+    expect_error(GRIMMER_test(2, 1, 10, return_list = bad))
+    expect_error(boundary_test(1, 10, 2, 1, 3, return_range = bad))
+  }
+  expect_error(GRIMMER_test(2, -1, 10))
+  expect_error(GRIM_test(Inf, 10))
+  expect_error(GRIM_test(1.23, 10, m_prec = 1))
+  expect_error(boundary_test(.2, 20, 3, .5, 4.5))
+  expect_error(boundary_test(1, 20, 3, 5, 1))
+  expect_error(GRIMMER_test(2, 1, 10, min_val = 0))
+  expect_identical(boundary_test(1.2, 20, 3.33, 1, 5, return_range = TRUE, quiet = TRUE),
+                   c(NA_real_, NA_real_))
+  expect_identical(boundary_test(1, 10, 8, 1, 5, return_range = TRUE, quiet = TRUE),
+                   c(NA_real_, NA_real_))
+  expect_no_warning(.sd_limits(28, 5.19, 1, 7, quiet = TRUE))
+  expect_no_warning(.sd_limits(1, 2, 1, 3, quiet = TRUE))
+  expect_error(GRIM_test(1e16, 10, quiet = TRUE), "reliable integer arithmetic")
+  expect_true(GRIM_test(2, 1e9, m_prec = 0, quiet = TRUE))
+})
+
+test_that("SD tests are invariant to large integer translations", {
+  for (offset in c(-1e8, 0, 1e8)) {
+    x <- c(1, 1, 2, 2) + offset
+    expect_true(boundary_test(round(sd(x), 2), 4, mean(x), 1 + offset, 2 + offset,
+                             m_prec = 1, sd_prec = 2))
+    expect_true(GRIMMER_test(mean(x), round(sd(x), 2), 4,
+                            m_prec = 1, sd_prec = 2, quiet = TRUE))
+  }
+})
+
+test_that("translation preserves mean-rounding ties", {
+  for (offset in c(-1e8, 0, 1e8)) for (m in seq(1.1, 1.9, .1)) {
+    for (real_mean in c(m - .05, m + .05)) {
+      total <- round(real_mean * 20)
+      x <- c(rep(1, 40 - total), rep(2, total - 20))
+      reported_sd <- round(sd(x), 2)
+      expect_true(GRIMMER_test(offset + m, reported_sd, 20, m_prec = 1,
+                              sd_prec = 2, quiet = TRUE))
+      expect_true(boundary_test(reported_sd, 20, offset + m, offset + 1,
+                               offset + 2, m_prec = 1, sd_prec = 2))
+    }
+  }
+})
+
+test_that("known samples pass GRIMMER and give exact SD bound extrema", {
+  failures <- character()
+  bound_failures <- character()
+  checked <- 0L
+  # Independently enumerate unordered samples using response frequencies.
+  for (items in 1:3) for (n in 2:6) {
+    lattice <- seq(0, 2, by = 1 / items)
+    counts <- as.matrix(expand.grid(rep(list(0:n), length(lattice))))
+    counts <- counts[rowSums(counts) == n, , drop = FALSE]
+    samples <- lapply(seq_len(nrow(counts)), function(i) rep(lattice, counts[i, ]))
+    means <- vapply(samples, mean, 0.0)
+    sds <- vapply(samples, sd, 0.0)
+    for (mp in 0:2) for (sp in 0:3) {
+      cases <- unique(data.frame(m = round(means, mp), s = round(sds, sp)))
+      for (i in seq_len(nrow(cases))) {
+        checked <- checked + 1L
+        if (!GRIMMER_test(cases$m[i], cases$s[i], n, mp, sp, items, quiet = TRUE)) {
+          failures <- c(failures, paste(items, n, mp, sp, cases$m[i], cases$s[i]))
+        }
+      }
+      for (m in unique(round(means, mp))) {
+        compatible <- abs(means - m) <= .5 * 10^-mp + 1e-10
+        expected <- c(round_down(min(sds[compatible]), sp), round_up(max(sds[compatible]), sp))
+        actual <- .sd_limits(n, m, 0, 2, mp, sp, items, quiet = TRUE)
+        if (!isTRUE(all.equal(actual, expected, tolerance = 1e-8))) {
+          bound_failures <- c(bound_failures, paste(items, n, mp, sp, m))
+        }
+      }
+    }
+  }
+  expect_equal(checked, 10489L)
+  expect_equal(failures, character())
+  expect_equal(bound_failures, character())
+})


### PR DESCRIPTION
The statistical checks could reject achievable summaries when SD and mean precision differed, for negative means, and when zero was a rounded SD. This makes precision inference shared, includes zero in the ordinary GRIMMER interval calculation, and applies one return formatter to every outcome. GRIM also returns every nearest reported mean at ties and avoids allocating candidates for logical-only calls.

- Ordinary use: correct SD precision, negative values, rounded-zero and multi-item constant samples; consistent GRIMMER return modes without requiring optional bounds; nearest-mean suggestions and quiet internal checks. Documentation now explains that passing GRIMMER is necessary but does not prove sample feasibility.
- Rare-case hardening: stable arithmetic for very large scale offsets, floating-point sum-of-squares boundaries, malformed flags/counts/precisions, invalid endpoints, and undefined boundary ranges. Arithmetic outside reliable representation and excessively large candidate lists now fail explicitly. These cases are much less likely on typical Likert scales.

The GRIMMER values/list modes now enumerate compatible candidates within the tested reporting interval; an empty vector always indicates failure. This removes the previous ambiguous empty-on-success contract. The intentionally retained `GRIM_test_old()` remains available.

Validation: the combined suite passes 331 assertions with no failures, warnings, or skips. All 10,489 independently enumerated known-valid GRIMMER cases and all 2,084 exact SD-bound comparisons pass. Regression coverage also includes the reported two-item floating-point boundary, return-mode combinations, negative/scientific precision, nearest-mean ties, and translation invariance at rounding ties. R CMD check reports 0 errors and 0 warnings; the temporary worktree caused a `.git` packaging note.

Coverage: Astra F04–F06, F10–F12 (statistical inputs), F17–F18; Fable 1/2/7/10–12/15/20, statistical parts of22, and23/24. [Astra report](https://rsprite2-audit-astra-2026-09-09.surge.sh/), [Fable report](https://rsprite2-audit.surge.sh/). No upstream rSPRITE changes.

Review: `claude -p --model fable` completed the full-scope review and two follow-ups. Its sole blocker was that removing the zero-SD shortcut admitted SDs below the response lattice’s minimum. A per-total minimum-variance condition now prevents that regression; the reviewer explicitly cleared it. It also cleared the aggregate allocation guard. The reviewer independently checked 57,570 cases, finding zero remaining below-minimum acceptances, and 400 random known-valid samples with zero rejections.

Final integration with reconstruction: 2,982 assertions pass, 120/120 seeded reconstructions succeed with valid invariants, and a clean-source R CMD check reports **0 errors, 0 warnings, 0 notes**.
